### PR TITLE
Better support for nested elements and custom element handler

### DIFF
--- a/Pod/Classes/BBCodeString.m
+++ b/Pod/Classes/BBCodeString.m
@@ -69,7 +69,9 @@
         NSRange range = [match range];
         
         NSString *word = [element.format substringWithRange:NSMakeRange(previousIndex, range.location - previousIndex)];
-        word = [self getTextForElement:element];
+        if (![word isEqualToString:@""] && ![element.tag isEqualToString:@""]) {
+            word = [self getTextForElement:element];
+        }
         [self createLabel:word forElement:element];
         
         NSString *tag = [element.format substringWithRange:range];

--- a/Pod/Classes/BBCodeString.m
+++ b/Pod/Classes/BBCodeString.m
@@ -69,6 +69,7 @@
         NSRange range = [match range];
         
         NSString *word = [element.format substringWithRange:NSMakeRange(previousIndex, range.location - previousIndex)];
+        word = [self getTextForElement:element];
         [self createLabel:word forElement:element];
         
         NSString *tag = [element.format substringWithRange:range];

--- a/Pod/Classes/BBCodeString.m
+++ b/Pod/Classes/BBCodeString.m
@@ -131,7 +131,12 @@
         [attributedString setColor:[self.layoutProvider getTextColor:element]];
     }
     
-    // This condition is just because of backwards compatibility for version 0.1.0
+    if ([self.layoutProvider respondsToSelector:@selector(getCustomDefinedAttributedString:)]) {
+        NSMutableAttributedString * customAttributedString = [self.layoutProvider getCustomDefinedAttributedString:element];
+        if (customAttributedString != nil) {
+            attributedString = customAttributedString;
+        }
+    }
     if ([self.layoutProvider respondsToSelector:@selector(getAttributesForElement:)])
     {
         NSDictionary *attributes = [self.layoutProvider getAttributesForElement:element];

--- a/Pod/Classes/BBCodeStringDelegate.h
+++ b/Pod/Classes/BBCodeStringDelegate.h
@@ -24,6 +24,9 @@
 /** Deprecated. Returns the text color for the given BBCode element. **/
 - (UIColor *)getTextColor:(BBElement *)element;
 
+/** Can handle custom behavior if needed. **/
+- (NSMutableAttributedString *)getCustomDefinedAttributedString:(BBElement *)element;
+
 @required
 
 /** Returns the whitelist of the BBCode tags your code supports. **/


### PR DESCRIPTION
Hi,
thanks for your awesome BB code implementations. To be able to handle particular cases with BB code, I needed to add some stuff to your project. One case was an unexpected handling of nested elements like [ul][li]. The other case is that I needed to handle [img] tags. For that I had to create the NSAttributedString in a different way.
Would be nice if you would add my changes, so that I can add it to my project via cocoapods again. 
